### PR TITLE
 Improve habit input validation by handling whitespace and duplicate entries

### DIFF
--- a/src/components/HabitForm.tsx
+++ b/src/components/HabitForm.tsx
@@ -173,6 +173,26 @@ export function HabitForm({ habitId, onClose, onHabitCreated, initial }: Props) 
   setSaving(true);
   setError('');
 
+  const trimmedName = name.trim();
+
+  //Empty / whitespace check
+  if (!trimmedName) {
+      setError ("Habit name cannot be empty");
+      setSaving(false);
+      return;
+}
+ //Duplicate check (ignore case + allow edit mode)
+  const isDuplicate = habits.some(
+  (h:any) =>
+  h.name.toLowerCase() === trimmedName.toLowercase() && h.id !== habitId
+  );
+
+  if (isDuplicate) {
+    setError ("Habit already exists");
+    setSaving (false);
+    return;
+  }
+
   const finalActiveDays = frequency === 'daily' ? ALL_DAYS : activeDays;
   const finalCategory = category.length > 0 ? category : [];
   const finalCategoryId = selectedCategoryId || null;
@@ -180,7 +200,7 @@ export function HabitForm({ habitId, onClose, onHabitCreated, initial }: Props) 
  try {
   if (habitId) {
     await updateHabit(habitId, {
-      name,
+      name: trimmedName,
       description,
       color,
       icon,
@@ -196,7 +216,7 @@ export function HabitForm({ habitId, onClose, onHabitCreated, initial }: Props) 
     });
   } else {
     const createdHabit = await createHabit({
-      name,
+      name: trimmedName,
       description,
       color,
       icon,


### PR DESCRIPTION
**### Description:**

This PR enhances the existing habit creation validation logic by addressing additional edge cases that were not previously handled.

**### Changes Made:**

- Trimmed input values to prevent whitespace only entries (e.g., ""   "")
- Added duplicate habit check (case-insensitive) to avoid repeated entries
- Ensured duplicate validation does not block editing the same habit
- Improved error handling by displaying appropriate messages to the user

**### Why this change is needed:**

While basic empty input validation exists, users could still:

- Add habits containing only spaces
- Create duplicate habits with the same name (e.g., "Gym" and "gym")

These cases lead to poor data quality and a confusing user experience. This update ensures cleaner and more consistent habit data.
### 
**How to test:**

1. Try adding a habit with only spaces → should show an error
2. Add a valid habit (e.g., "Gym") → should work
3. Try adding "gym" again → should show duplicate error
4. Edit an existing habit without changing its name → should work normally