### PR TITLE
fix: add maxLength of 50 to habit name input with character counter

### DIFF
--- a/src/components/HabitForm.tsx
+++ b/src/components/HabitForm.tsx
@@ -291,15 +291,19 @@ export function HabitForm({ habitId, onClose, onHabitCreated, initial }: Props) 
             <label htmlFor="habit-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Habit Name
             </label>
-            <input
+           <input
               id="habit-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
+              maxLength={50}
               placeholder="e.g., Morning Exercise"
               className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
             />
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1 text-right">
+              {name.length}/50
+            </p>
           </div>
 
           <div>


### PR DESCRIPTION
Fixes #96

### Changes Made
- Added `maxLength={50}` to the habit name input field in `HabitForm.tsx`
- Added a live character counter below the input showing `{name.length}/50`

### What this fixes
Prevents users from entering extremely long habit names that overflow the dashboard card layout.